### PR TITLE
Handle blank lines and templated critical.cfg

### DIFF
--- a/cgi/xymon2json
+++ b/cgi/xymon2json
@@ -86,8 +86,15 @@ def merge_critical_scores():
         critical_score = defaultdict(dict)
         with open(CRITICAL, 'r') as f:
             for line in f:
-                (host, test, _, _, _, score) = line.split('|')[:6]
-                critical_score[host][test] = score
+                if "|" in line:
+                    try:
+                        (host, test, _, _, _, score) = line.split('|')[:6]
+                        critical_score[host][test] = score
+                    except:
+                        (host, template) = line.split('|=')[:2]
+                        template = template.rstrip("\n\r")
+                        for test in critical_score[template]:
+                            critical_score[host][test] = critical_score[template][test]
 
         for i in range(len(xymon_data)):
             host = xymon_data[i]['hostname']


### PR DESCRIPTION
This change handles when critical.cfg is based on templates and also ignores lines that have no "|" symbol in them
e.g.
LinuxServer|disk||||1|Technician|Check Hardware|iain 2014-10-21 17:40:24
linuxserver1|=LinuxServer
linuxserver2|=LinuxServer